### PR TITLE
Retrieve data from result if result.data is undefined

### DIFF
--- a/lib/populate/index.js
+++ b/lib/populate/index.js
@@ -68,9 +68,8 @@ module.exports = function populate (options) {
         find.query[option.f_key] = value;
         return hook.app.service(option.service).find(find).
           then(result => {
-            let data = result.data;
-            if (option.one) data = result.data[0];
-            obj[key] = data;
+            let data = result.data || result;
+            obj[key] = option.one ? data[0] : data;
             return;
           });
       };


### PR DESCRIPTION
In some circumstances (I'm not completely sure when this changes), the data is in `result` rather than `result.data`.